### PR TITLE
Tool containerization

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,38 @@
+name: dockerhub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Clean up the release tag
+        id: cleantag
+        run: |
+          tag=$(echo ${{ github.event.release.tag_name }} | tr -d v)
+          echo "::set-output name=tag::${{ github.repository }}:${clean%"_scope2screen"}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{steps.cleantag.outputs.tag}}
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -13,7 +13,7 @@ jobs:
         id: cleantag
         run: |
           tag=$(echo ${{ github.event.release.tag_name }} | tr -d v)
-          echo "::set-output name=tag::${{ github.repository }}:${clean%"_scope2screen"}
+          echo "::set-output name=tag::${{ github.repository }}:${tag%"_scope2screen"}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.7
+
+RUN apt-get update && \
+    apt-get install -y python3-opencv && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install \
+    Flask==1.1.2 \
+    jinja2==3.0.3 \
+    werkzeug==2.0.3 \
+    itsdangerous==2.0.1 \
+    flask-sqlalchemy \
+    numpy \
+    opencv-python \
+    orjson \
+    pandas \
+    pillow==8.1.1 \
+    requests \
+    scikit-learn \
+    scikit-image \
+    scipy \
+    tifffile==2021.4.8 \
+    waitress \
+    zarr==2.10.1 \
+    ome-types==0.2.9 \
+    dask \
+    "dask[dataframe]"
+
+COPY . /app
+
+CMD ["python", "/app/run.py"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ Releases can be found here:
 https://github.com/labsyspharm/scope2screen/releases
 These are executables for Windows and MacOS that can be run locally without any installations.
 
+## Running as a Docker container
+
+From the directory that contains your data files:
+
+`docker run --rm -v "$PWD":/data -p 8000:8000 labsyspharm/scope2screen:0.74`
+
+where
+* `--rm` cleans up the container after it finishes executing
+* `-v` mounts the "present working directory" (containing your data) to be `/data` inside the container
+* `-p` forwards the port 8000
+* `0.74` specifies the tool version (see [Releases](https://github.com/labsyspharm/scope2screen/releases))
+
+Once the container is running, go to `http://localhost:8000/` in your web browser.
 
 ## Clone and Run Codebase (for Developers)
 #### Checkout Project


### PR DESCRIPTION
* Added a `Dockerfile` defining the container image
* Added a GitHub Actions workflow that will automatically build and push the container image to Dockerhub whenever a new release is published. Note that the release tag will be stripped of the leading `v` and the trailing `_scope2screen`.
* Added instructions on running the container to README